### PR TITLE
加入文章发布时间的显示

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@octokit/rest": "^17.11.0",
     "dotenv": "^8.2.0",
     "jsdom": "^16.2.2",
+    "moment": "^2.27.0",
     "node-fetch": "^2.6.0"
   },
   "devDependencies": {}

--- a/src/renderToMarkdown.js
+++ b/src/renderToMarkdown.js
@@ -1,9 +1,10 @@
+let moment = require('moment')
 
 function strip(str) {
   return str.replace(/(^\s*|\s*$)/g, '')
 }
 
-module.exports = function({title, author, dom}) {
+module.exports = function({title, author, publishTime, dom}) {
   let mdTitle = ''
   if (author) {
     mdTitle = `${strip(title)} by ${strip(author)}`
@@ -17,10 +18,14 @@ module.exports = function({title, author, dom}) {
     element.removeAttribute('style')
   })
 
+  let mdPublishDate = publishTime ? moment(publishTime * 1000).utcOffset(8).format('YYYY-MM-DD') : '';
 
   let html = dom.innerHTML
   let mdBody = html.split("\n").map(line => strip(line)).join('')
 
-
-  return `${mdTitle}\n------\n${mdBody}`
+  if (mdPublishDate) {
+    return `${mdTitle}\n------\n**${mdPublishDate}**\n${mdBody}`
+  } else {
+    return `${mdTitle}\n------\n${mdBody}`
+  }
 }

--- a/websites/weixin.js
+++ b/websites/weixin.js
@@ -8,6 +8,22 @@ module.exports = {
     return parsed.hostname == 'mp.weixin.qq.com'
   },
 
+  getPublishTime(document) {
+    let time
+    let timeFound = Array.from(document.querySelectorAll('script')).some(v=>{
+      let m = /var \w+="\d*",\w+="(\d*)",\w+="[\d-]*";/g.exec(v.textContent)
+      if (m) {
+        time = Number.parseInt(m[1])
+      }
+      return !!m
+    })
+    if (!timeFound) {
+      return
+    } else {
+      return time
+    }
+  },
+
   async process(url) {
     let res = await fetch(url)
     let html = await res.text()
@@ -16,6 +32,7 @@ module.exports = {
     let title = document.querySelector('#activity-name').textContent
     let author = document.querySelector('#js_name').textContent
     let content = document.querySelector('#js_content')
+    let publishTime = this.getPublishTime(document)
 
     Array.from(content.querySelectorAll('img')).map(img => {
       if (img.dataset.src) {
@@ -26,6 +43,7 @@ module.exports = {
     return {
       title,
       author,
+      publishTime,
       dom: content
     }
 


### PR DESCRIPTION
可以从抓取的页面里提取发布时间并显示出来，暂时先只做了微信公众号的，其他未适配网站的显示效果不受影响。
效果大概像这样 [https://github.com/SemiGhost/duty-machine/issues/3](https://github.com/SemiGhost/duty-machine/issues/3)
显示的时区用的是UTC+08:00